### PR TITLE
Add input transitions during freeze frames

### DIFF
--- a/editor/tools/CETool-FrameData.gd
+++ b/editor/tools/CETool-FrameData.gd
@@ -1,0 +1,81 @@
+extends "res://castagne/editor/tools/CastagneEditorTool.gd"
+
+var topRow
+var botRow
+
+func SetupTool():
+	topRow = $Table/TopRow
+	botRow = $Table/BotRow
+	toolName = "Frame Data Display"
+	toolDescription = "Made by crosseyed. Tool that displays the frame data of the most recently performed attack.\n To display Startup, Active, and Recovery frames, use AttackParam(Startup, X), AttackParam(ACtive, X), and AttackParam(Recovery, X).\n To include knockdown time into hit advantage use AttackParam(KDTime, X).\n Currently does not support multihits."
+
+func OnEngineRestarted(engine):
+	var editorModule = engine.configData.GetModuleSlot(Castagne.MODULE_SLOTS_BASE.EDITOR)
+	editorModule.connect("EngineTick_PhysicsStartEntity", self, "EngineTick_PhysicsStartEntity")
+	
+func EngineTick_PhysicsStartEntity(stateHandle):
+	if stateHandle.GetPlayer() == 0:
+		CollectFrameData(stateHandle)
+
+func CollectFrameData(stateHandle):
+	var attackData = stateHandle.EntityGet("_AttackData")
+	var attackName = stateHandle.EntityGet("_State")
+	var damage = attackData["Damage"]
+	var hitstun = attackData["Hitstun"]
+	var blockstun = attackData["Blockstun"]
+	var flags = attackData["Flags"].duplicate()
+	var initialProration = attackData["StarterProrationDamage"]
+	var proration = attackData["ProrationDamage"]
+	
+	var startup = 0
+	if attackData.has("Startup"):
+		startup = attackData["Startup"]
+	var active = 0
+	if attackData.has("Active"):
+		active = attackData["Active"]
+	var recovery = 0
+	if attackData.has("Recovery"):
+		recovery = attackData["Recovery"]
+	
+	var noteKD = ""
+	var knockdownTime = 0
+	if attackData.has("KDTime"):
+		knockdownTime = attackData["KDTime"]
+		noteKD = " (KD)"
+	
+	var duration = startup + active + recovery - 1
+	var hitAdv = hitstun - (active + recovery) + knockdownTime
+	var blockAdv = blockstun - (active + recovery)
+	
+	var guard = "Mid"
+	if flags.has("Mid"):
+		flags.erase("Mid")
+	if flags.has("Overhead"):
+		guard = "High"
+		flags.erase("Overhead")
+	if flags.has("Low"):
+		guard = "Low"
+		flags.erase("Low")
+	if flags.has("Throw"):
+		guard = "Throw"
+		flags.erase("Throw")
+	
+	var propertiesList = []
+	for f in flags:
+		propertiesList += [f]
+	if propertiesList.empty():
+		propertiesList += ["N/A"]
+	var properties = PoolStringArray(propertiesList).join(", ")
+	
+	if stateHandle.EntityHasFlag("Attacking"):
+		topRow.get_node("Name/Value").set_text(attackName)
+		topRow.get_node("Damage/Value").set_text(str(damage))
+		topRow.get_node("Startup/Value").set_text(str(startup))
+		topRow.get_node("Active/Value").set_text(str(active))
+		topRow.get_node("Recovery/Value").set_text(str(recovery))
+		
+		botRow.get_node("Proration/Value").set_text(str(initialProration)+", "+str(proration))
+		botRow.get_node("Guard/Value").set_text(guard)
+		botRow.get_node("Properties/Value").set_text(str(properties))
+		botRow.get_node("Advantage/Value").set_text(("+" if sign(hitAdv)==1 else "")+str(hitAdv)+noteKD+" / "+("+" if sign(blockAdv)==1 else "")+str(blockAdv))
+	

--- a/editor/tools/CETool-FrameData.tscn
+++ b/editor/tools/CETool-FrameData.tscn
@@ -1,0 +1,272 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://castagne/editor/tools/CETool-FrameData.gd" type="Script" id=1]
+
+[node name="FrameData" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource( 1 )
+
+[node name="Table" type="VBoxContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 0.2
+
+[node name="TopRow" type="HBoxContainer" parent="Table"]
+margin_right = 1920.0
+margin_bottom = 106.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="Name" type="VBoxContainer" parent="Table/TopRow"]
+margin_right = 380.0
+margin_bottom = 106.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="Property" type="Label" parent="Table/TopRow/Name"]
+margin_right = 380.0
+margin_bottom = 51.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+text = "Attack"
+align = 1
+valign = 1
+
+[node name="Value" type="Label" parent="Table/TopRow/Name"]
+margin_top = 55.0
+margin_right = 380.0
+margin_bottom = 106.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+align = 1
+valign = 1
+
+[node name="Damage" type="VBoxContainer" parent="Table/TopRow"]
+margin_left = 384.0
+margin_right = 765.0
+margin_bottom = 106.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="Property" type="Label" parent="Table/TopRow/Damage"]
+margin_right = 381.0
+margin_bottom = 51.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+text = "Damage"
+align = 1
+valign = 1
+
+[node name="Value" type="Label" parent="Table/TopRow/Damage"]
+margin_top = 55.0
+margin_right = 381.0
+margin_bottom = 106.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+align = 1
+valign = 1
+
+[node name="Startup" type="VBoxContainer" parent="Table/TopRow"]
+margin_left = 769.0
+margin_right = 1150.0
+margin_bottom = 106.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="Property" type="Label" parent="Table/TopRow/Startup"]
+margin_right = 381.0
+margin_bottom = 51.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+text = "Startup"
+align = 1
+valign = 1
+
+[node name="Value" type="Label" parent="Table/TopRow/Startup"]
+margin_top = 55.0
+margin_right = 381.0
+margin_bottom = 106.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+align = 1
+valign = 1
+
+[node name="Active" type="VBoxContainer" parent="Table/TopRow"]
+margin_left = 1154.0
+margin_right = 1535.0
+margin_bottom = 106.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="Property" type="Label" parent="Table/TopRow/Active"]
+margin_right = 381.0
+margin_bottom = 51.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+text = "Active"
+align = 1
+valign = 1
+
+[node name="Value" type="Label" parent="Table/TopRow/Active"]
+margin_top = 55.0
+margin_right = 381.0
+margin_bottom = 106.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+align = 1
+valign = 1
+
+[node name="Recovery" type="VBoxContainer" parent="Table/TopRow"]
+margin_left = 1539.0
+margin_right = 1920.0
+margin_bottom = 106.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="Property" type="Label" parent="Table/TopRow/Recovery"]
+margin_right = 381.0
+margin_bottom = 51.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+text = "Recovery"
+align = 1
+valign = 1
+
+[node name="Value" type="Label" parent="Table/TopRow/Recovery"]
+margin_top = 55.0
+margin_right = 381.0
+margin_bottom = 106.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+align = 1
+valign = 1
+
+[node name="BotRow" type="HBoxContainer" parent="Table"]
+margin_top = 110.0
+margin_right = 1920.0
+margin_bottom = 216.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="Proration" type="VBoxContainer" parent="Table/BotRow"]
+margin_right = 380.0
+margin_bottom = 106.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="Property" type="Label" parent="Table/BotRow/Proration"]
+margin_right = 380.0
+margin_bottom = 51.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+text = "Proration"
+align = 1
+valign = 1
+
+[node name="Value" type="Label" parent="Table/BotRow/Proration"]
+margin_top = 55.0
+margin_right = 380.0
+margin_bottom = 106.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+align = 1
+valign = 1
+
+[node name="Guard" type="VBoxContainer" parent="Table/BotRow"]
+margin_left = 384.0
+margin_right = 765.0
+margin_bottom = 106.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="Property" type="Label" parent="Table/BotRow/Guard"]
+margin_right = 381.0
+margin_bottom = 51.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+text = "Guard"
+align = 1
+valign = 1
+
+[node name="Value" type="Label" parent="Table/BotRow/Guard"]
+margin_top = 55.0
+margin_right = 381.0
+margin_bottom = 106.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+align = 1
+valign = 1
+
+[node name="Properties" type="VBoxContainer" parent="Table/BotRow"]
+margin_left = 769.0
+margin_right = 1150.0
+margin_bottom = 106.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="Property" type="Label" parent="Table/BotRow/Properties"]
+margin_right = 381.0
+margin_bottom = 51.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+text = "Properties"
+align = 1
+valign = 1
+
+[node name="Value" type="Label" parent="Table/BotRow/Properties"]
+margin_top = 55.0
+margin_right = 381.0
+margin_bottom = 106.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+align = 1
+valign = 1
+
+[node name="Advantage" type="VBoxContainer" parent="Table/BotRow"]
+margin_left = 1154.0
+margin_right = 1535.0
+margin_bottom = 106.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="Property" type="Label" parent="Table/BotRow/Advantage"]
+margin_right = 381.0
+margin_bottom = 51.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+text = "Advantage"
+align = 1
+valign = 1
+
+[node name="Value" type="Label" parent="Table/BotRow/Advantage"]
+margin_top = 55.0
+margin_right = 381.0
+margin_bottom = 106.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+align = 1
+valign = 1
+
+[node name="Extra1" type="VBoxContainer" parent="Table/BotRow"]
+margin_left = 1539.0
+margin_right = 1920.0
+margin_bottom = 106.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="Property" type="Label" parent="Table/BotRow/Extra1"]
+margin_right = 381.0
+margin_bottom = 51.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+align = 1
+valign = 1
+
+[node name="Value" type="Label" parent="Table/BotRow/Extra1"]
+margin_top = 55.0
+margin_right = 381.0
+margin_bottom = 106.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+align = 1
+valign = 1

--- a/engine/CastagneEngine.gd
+++ b/engine/CastagneEngine.gd
@@ -112,12 +112,14 @@ func EngineTick(previousMemory, playerInputs):
 	
 	if(gameStateHandle.GlobalGet("_FrozenFrame")):
 		var activeEIDs = gameStateHandle.GlobalGet("_ActiveEntities")
-		for module in modules:
-			module.ResetVariables(gameStateHandle, activeEIDs)
-		#var inputPhaseFunction = funcref(configData.GetModuleSlot(Castagne.MODULE_SLOTS_BASE.INPUT), "InputPhase")
-		#ExecuteInternalPhase("Input", activeEIDs, gameStateHandle, inputPhaseFunction)
+		
+		var inputPhaseFunction = funcref(configData.GetModuleSlot(Castagne.MODULE_SLOTS_BASE.INPUT), "InputPhase")
+		ExecuteInternalPhase("Input", activeEIDs, gameStateHandle, inputPhaseFunction)
+		
 		ExecuteScriptPhase("Freeze", activeEIDs, gameStateHandle)
 		
+		for module in modules:
+			module.ResetVariables(gameStateHandle, activeEIDs)
 		
 		for m in modules:
 			m.FrameEnd(gameStateHandle)

--- a/modules/coreset/CMInput.gd
+++ b/modules/coreset/CMInput.gd
@@ -212,7 +212,9 @@ func InputPhaseEndEntity(stateHandle):
 		stateHandle.EntitySet("_SelectedInputTransition",inputTransition)
 
 func FreezePhaseStartEntity(stateHandle):
-	var inputTransitionList = stateHandle.EntityGet("_InputTransitionList")
+	var inputTransitionList = []
+	if stateHandle.EntityHasFlag("Attacking"):
+		inputTransitionList = stateHandle.EntityGet("_InputTransitionList")
 	if !inputTransitionList.empty():
 		stateHandle.EntitySet("_FrozenInputTransitionList",inputTransitionList)
 

--- a/modules/coreset/CMInput.gd
+++ b/modules/coreset/CMInput.gd
@@ -70,6 +70,8 @@ func ModuleSetup():
 		"Types":["str", "str", "int"],
 		})
 	RegisterVariableEntity("_InputTransitionList", [], ["ResetEachFrame"], {"Description":"List of the input transitions to watch for."})
+	RegisterVariableEntity("_FrozenInputTransitionList", [], {"Description":"List of the input transitions to watch for while in a freeze frame state, prevserved from the last frame before the freeze."})
+	RegisterVariableEntity("_SelectedInputTransition", null, {"Description":"Holds the current state determined from inputs to transition to during the reaction phase."})
 	RegisterConfig("InputTransitionDefaultPriority", 1000, {"Description":"The default Transition priority for InputTransition."})
 
 	RegisterCategory("Motion Inputs", {"Description":"System for detecting when motion input has been performed by a player."})
@@ -88,7 +90,7 @@ func ModuleSetup():
 	RegisterVariableEntity("_DirectionalInputLog", [], null, {"Description":"Array containing just the raw directional inputs for a player on each frame. Inputs are held for a number of frames equal to the buffer config variable."})
 	RegisterVariableEntity("_ChargeInputLog", [], null, {"Description":"Array containing the inputs that have been held long enough to charge on each frame. Diagonal inputs also add the cardinal direction inputs. Inputs are held for a number of frames equal to the buffer config variable."})
 	RegisterVariableEntity("_ChargeTime", {"Up":0,"Down":0,"Forward":0,"Back":0}, null, {"Description":"Dict containing the number of frames each direction has been held."})
-	RegisterVariableEntity("_PerformedMotions", [], ["ResetEachFrame"], {"Description":"Array containing the motions that have been performed by the player."})
+	RegisterVariableEntity("_PerformedMotions", [], {"Description":"Array containing the motions that have been performed by the player."})
 	
 var _castagneInputScript = load("res://castagne/engine/CastagneInput.gd")
 func OnModuleRegistration(configData):
@@ -146,7 +148,6 @@ func InitPhaseEndEntity(stateHandle):
 	var inputData = inputsProcessed[stateHandle.EntityGet("_Player")].duplicate()
 	stateHandle.EntitySet("_Inputs", inputData)
 
-
 func InputPhase(stateHandle, activeEIDs):
 	var castagneInput = stateHandle.Input()
 	var inputSchema = castagneInput.GetInputSchema()
@@ -202,12 +203,26 @@ func InputPhaseEndEntity(stateHandle):
 			if MotionInputCheck(stateHandle, m):
 				motions += [m]
 		stateHandle.EntitySet("_PerformedMotions", motions)
+	
+	var frozenITL = stateHandle.EntityGet("_FrozenInputTransitionList")
+	if !frozenITL.empty():
+		stateHandle.EntitySet("_InputTransitionList",frozenITL)
+	var inputTransition = FindCorrectInputTransition(stateHandle)
+	if(inputTransition != null):
+		stateHandle.EntitySet("_SelectedInputTransition",inputTransition)
+
+func FreezePhaseStartEntity(stateHandle):
+	var inputTransitionList = stateHandle.EntityGet("_InputTransitionList")
+	if !inputTransitionList.empty():
+		stateHandle.EntitySet("_FrozenInputTransitionList",inputTransitionList)
 
 func ReactionPhaseStartEntity(stateHandle):
-	var inputTransition = FindCorrectInputTransition(stateHandle)
+	var inputTransition = stateHandle.EntityGet("_SelectedInputTransition")
 	if(inputTransition != null):
 		var coreModule = stateHandle.ConfigData().GetModuleSlot(Castagne.MODULE_SLOTS_BASE.CORE)
 		coreModule.Transition([inputTransition["TargetState"], inputTransition["Priority"]], stateHandle)
+	stateHandle.EntitySet("_SelectedInputTransition",null)
+	stateHandle.EntitySet("_FrozenInputTransitionList",[])
 
 func FindCorrectInputTransition(stateHandle):
 	var inputTransitionList = stateHandle.EntityGet("_InputTransitionList")


### PR DESCRIPTION
Allows inputs transitions to be found and stored during freeze frames so the transition occurs the frame after. This should make combos feel a lot smoother as the next attack can be input during the hitstun of the previous one.