### PR TITLE
Add motion input alias system, fix hitstun/hitstop cancelling bug, more support for charge inputs

### DIFF
--- a/editor/CastagneEditor.tscn
+++ b/editor/CastagneEditor.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=22 format=2]
+[gd_scene load_steps=23 format=2]
 
 [ext_resource path="res://castagne/editor/CastagneEditor.gd" type="Script" id=1]
 [ext_resource path="res://castagne/editor/CastagneEditorConfig.gd" type="Script" id=2]
@@ -21,6 +21,7 @@
 [ext_resource path="res://castagne/editor/submenus/character/CECharacterSet.tscn" type="PackedScene" id=19]
 [ext_resource path="res://castagne/editor/submenus/music/CEMusicSettings.tscn" type="PackedScene" id=20]
 [ext_resource path="res://castagne/editor/submenus/character/CECharacterAddNew.tscn" type="PackedScene" id=21]
+[ext_resource path="res://castagne/editor/submenus/input/CEInputMotionAliases.tscn" type="PackedScene" id=22]
 
 [node name="CastagneEditor" type="Control"]
 anchor_right = 1.0
@@ -1149,10 +1150,14 @@ text = "Cancel"
 [node name="InputConfig" parent="." instance=ExtResource( 16 )]
 visible = false
 
+[node name="InputMotionAliases" parent="." instance=ExtResource( 22 )]
+visible = false
+
 [node name="CharacterSet" parent="." instance=ExtResource( 19 )]
 visible = false
 
 [node name="MusicSettings" parent="." instance=ExtResource( 20 )]
+visible = false
 
 [node name="ModuleSet" parent="." instance=ExtResource( 18 )]
 visible = false

--- a/editor/submenus/input/CEInputMotionAliases.gd
+++ b/editor/submenus/input/CEInputMotionAliases.gd
@@ -1,0 +1,75 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+extends "../CastagneEditorSubmenu.gd"
+
+var listLength = 1
+onready var listCont = $Data/VBoxContainer
+
+func Enter():
+	var aliases = editor.configData.Get("MotionAliases").duplicate(true)
+	var delete = listCont.get_node("0/Delete")
+	delete.connect("pressed", self, "_on_Delete_pressed", [delete])
+	if listLength < len(aliases):
+		AddField(len(aliases) - listLength)
+	for i in range(len(aliases)):
+		listCont.get_node(str(i)).get_node("Name").set_text(aliases[i]["Name"])
+		listCont.get_node(str(i)).get_node("Alias").set_text(aliases[i]["Aliases"])
+
+func _on_Confirm_pressed():
+	var aliases = []
+	aliases.resize(listLength)
+	for i in range(listLength):
+		aliases[i] = {
+			"Name":listCont.get_node(str(i)).get_node("Name").get_text(),
+			"Aliases":listCont.get_node(str(i)).get_node("Alias").get_text()
+		}
+	editor.configData.Set("MotionAliases", aliases)
+	Exit(OK)
+
+func _on_Cancel_pressed():
+	Exit()
+
+
+func _on_AddField_pressed():
+	AddField()
+
+func AddField(num = 1):
+	var addButton = listCont.get_node("AddField")
+	if num < 1:
+		return
+	for i in range(listLength, listLength + num):
+		var newField = listCont.get_node("0").duplicate()
+		newField.set_name(str(i))
+		newField.get_node("Name").set_text("")
+		newField.get_node("Alias").set_text("")
+		
+		var newDelete = newField.get_node("Delete")
+		newDelete.connect("pressed", self, "_on_Delete_pressed", [newDelete])
+		
+		listCont.add_child(newField)
+		listCont.move_child(addButton, addButton.get_index() + 1)
+	listLength += num
+
+func DeleteField(index):
+	if index < 0 || index >= listLength:
+		return
+	if listLength <= 1:
+		listCont.get_node("0/Name").set_text("")
+		listCont.get_node("0/Alias").set_text("")
+		return
+	
+	#have to rename here so the queue'd node isn't preventing other nodes from being renamed
+	listCont.get_node(str(index)).set_name("x")
+	listCont.get_node("x").queue_free()
+	
+	for i in range(index + 1, listLength):
+		listCont.get_node(str(i)).set_name(str(i-1))
+	
+	listLength -= 1
+
+func _on_Delete_pressed(button):
+	#I think its simplest to use the name of the container as the index
+	var index = int(button.get_parent().get_name())
+	DeleteField(index)

--- a/editor/submenus/input/CEInputMotionAliases.tscn
+++ b/editor/submenus/input/CEInputMotionAliases.tscn
@@ -1,0 +1,135 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://castagne/editor/submenus/input/CEInputMotionAliases.gd" type="Script" id=1]
+
+[node name="InputMotionAliases" type="Control"]
+anchor_left = 0.1
+anchor_top = 0.1
+anchor_right = 0.9
+anchor_bottom = 0.9
+rect_pivot_offset = Vector2( 868, 314 )
+script = ExtResource( 1 )
+
+[node name="Panel" type="Panel" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="ColorRect" type="ColorRect" parent="."]
+anchor_right = 1.0
+margin_bottom = 32.0
+color = Color( 0, 0, 0, 0.376471 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Title" type="Label" parent="."]
+anchor_right = 1.0
+margin_bottom = 14.0
+rect_min_size = Vector2( 0, 32 )
+text = "Motion Input Aliases"
+align = 1
+valign = 1
+
+[node name="Data" type="Control" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 16.0
+margin_top = 48.0
+margin_right = -16.0
+margin_bottom = -64.0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Data"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="Titles" type="HBoxContainer" parent="Data/VBoxContainer"]
+margin_right = 992.0
+margin_bottom = 32.0
+
+[node name="Title" type="Label" parent="Data/VBoxContainer/Titles"]
+margin_right = 237.0
+margin_bottom = 32.0
+rect_min_size = Vector2( 0, 32 )
+size_flags_horizontal = 3
+text = "Input Name"
+align = 1
+valign = 1
+
+[node name="Title2" type="Label" parent="Data/VBoxContainer/Titles"]
+margin_left = 241.0
+margin_right = 952.0
+margin_bottom = 32.0
+rect_min_size = Vector2( 0, 32 )
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 3.0
+text = "Aliases"
+align = 1
+valign = 1
+
+[node name="Title3" type="Label" parent="Data/VBoxContainer/Titles"]
+margin_left = 956.0
+margin_top = 9.0
+margin_right = 992.0
+margin_bottom = 23.0
+text = "         "
+
+[node name="0" type="HBoxContainer" parent="Data/VBoxContainer"]
+margin_top = 36.0
+margin_right = 992.0
+margin_bottom = 60.0
+
+[node name="Name" type="LineEdit" parent="Data/VBoxContainer/0"]
+margin_right = 236.0
+margin_bottom = 24.0
+size_flags_horizontal = 3
+
+[node name="Alias" type="LineEdit" parent="Data/VBoxContainer/0"]
+margin_left = 240.0
+margin_right = 950.0
+margin_bottom = 24.0
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 3.0
+
+[node name="Delete" type="Button" parent="Data/VBoxContainer/0"]
+margin_left = 954.0
+margin_right = 992.0
+margin_bottom = 24.0
+text = "Del."
+
+[node name="AddField" type="Button" parent="Data/VBoxContainer"]
+margin_top = 64.0
+margin_right = 91.0
+margin_bottom = 84.0
+size_flags_horizontal = 0
+text = "  Add Input  "
+
+[node name="Buttons" type="HBoxContainer" parent="."]
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 16.0
+margin_top = -48.0
+margin_right = -16.0
+margin_bottom = -16.0
+
+[node name="Confirm" type="Button" parent="Buttons"]
+margin_right = 673.0
+margin_bottom = 32.0
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 1.5
+text = "Confirm"
+
+[node name="Cancel" type="Button" parent="Buttons"]
+margin_left = 677.0
+margin_right = 992.0
+margin_bottom = 32.0
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 0.7
+text = "Cancel"
+
+[connection signal="pressed" from="Data/VBoxContainer/AddField" to="." method="_on_AddField_pressed"]
+[connection signal="pressed" from="Buttons/Confirm" to="." method="_on_Confirm_pressed"]
+[connection signal="pressed" from="Buttons/Cancel" to="." method="_on_Cancel_pressed"]

--- a/modules/general/CMInput.gd
+++ b/modules/general/CMInput.gd
@@ -97,9 +97,7 @@ func ModuleSetup():
 		"Types":["str", "str", "str", "int"],
 		})
 	RegisterVariableEntity("_InputTransitionList", [], ["ResetEachFrame"], {"Description":"List of the input transitions to watch for."})
-	RegisterVariableEntity("_FrozenInputTransitionList", [], null, {"Description":"List of the input transitions to watch for while in a freeze frame state, prevserved from the last frame before the freeze."})
-	RegisterVariableEntity("_SelectedInputTransition", null, {"Description":"Holds the current state determined from inputs to transition to during the reaction phase."})
-	RegisterVariableEntity("_SelectedFrozenInputTransition", null, {"Description":"Holds the input transition data during the freeze phase."})
+	RegisterVariableEntity("_FrozenInputTransition", null, {"Description":"Holds the input transition data during the freeze phase."})
 	RegisterConfig("InputTransitionDefaultPriority", 1000, {"Description":"The default Transition priority for InputTransition."})
 
 	RegisterCategory("Motion Inputs", {"Description":"System for detecting when motion input has been performed by a player."})
@@ -111,7 +109,7 @@ func ModuleSetup():
 	RegisterConfig("LongMotionInterval", 8, {"Description":"Maximum number of frames between inputs for a motion to remain valid. This value is for motions with more than three directions.", "Flags":["Advanced"]})
 	RegisterConfig("ButtonInterval", 8, {"Description":"Maximum number of frames between motion input and pressing the button for a motion to remain valid.", "Flags":["Advanced"]})
 	RegisterConfig("MinChargeTime", 30, {"Description":"Minimum number of frames for a direction to be held for a valid charge input.", "Flags":["Advanced"]})
-	#the above three values determine the number of frames between inputs in a motion. By default, shorter motions have more leniency.
+	RegisterConfig("StrictDiagonalCharge", false, {"Description":"If enabled, holding a diagonal direction will not count as charing the two diagional inputs.", "Flags":["Advanced"]})
 	
 	RegisterConfig("MotionAliases", [
 		{"Name":"360","Aliases":"2684, 6842, 8426, 4268"},
@@ -122,8 +120,6 @@ func ModuleSetup():
 	RegisterCustomConfig("Define Motion Input Aliases", "InputMotionAliases", {"Flags":["Advanced", "ReloadFull", "LockBack"]})
 
 	RegisterVariableEntity("_DirectionalInputLog", [], null, {"Description":"Array containing just the raw directional inputs for a player on each frame. Inputs are held for a number of frames equal to the buffer config variable."})
-	RegisterVariableEntity("_ChargeInputLog", [], null, {"Description":"Array containing the inputs that have been held long enough to charge on each frame. Diagonal inputs also add the cardinal direction inputs. Inputs are held for a number of frames equal to the buffer config variable."})
-	RegisterVariableEntity("_ChargeTime", {"Up":0,"Down":0,"Forward":0,"Back":0}, null, {"Description":"Dict containing the number of frames each direction has been held."})
 
 var _castagneInputScript = load("res://castagne/engine/CastagneInput.gd")
 func OnModuleRegistration(configData):
@@ -229,20 +225,25 @@ func InputPhaseEndEntity(stateHandle):
 	if(stateHandle.ConfigData().Get("EnableMotionInputs")):
 		LogDirectionalInputs(stateHandle)
 
+#checks for inputs during the freeze phase
 func FreezePhaseStartEntity(stateHandle):
-	var frozenInputTransitionList = []
-	frozenInputTransitionList = stateHandle.EntityGet("_FrozenInputTransitionList")
-	if(!frozenInputTransitionList.empty()):
-		stateHandle.EntitySet("_InputTransitionList", frozenInputTransitionList)
-		var frozenInputTransition = FindCorrectInputTransition(stateHandle)
-		if(frozenInputTransition != null):
-			stateHandle.EntitySet("_SelectedFrozenInputTransition", frozenInputTransition)
+	var frozenInputTransition = FindCorrectInputTransition(stateHandle)
+	if frozenInputTransition != null:
+		stateHandle.EntitySet("_FrozenInputTransition", frozenInputTransition)
 
 func ReactionPhaseStartEntity(stateHandle):
 	var inputTransition = FindCorrectInputTransition(stateHandle)
-	var frozenInputTransition = stateHandle.EntityGet("_SelectedFrozenInputTransition")
-	if(inputTransition == null):
-		inputTransition = frozenInputTransition
+	var frozenIT = stateHandle.EntityGet("_FrozenInputTransition")
+	
+	#checks if there is an input from the freeze phase that is still a valid input and sets it as the input transition
+	if frozenIT != null:
+		if inputTransition == null:
+			var itl = stateHandle.EntityGet("_InputTransitionList")
+			for input in itl:
+				if input["TargetState"] == frozenIT["TargetState"]:
+					inputTransition = frozenIT
+					break
+		stateHandle.EntitySet("_FrozenInputTransition", null)
 	
 	if(inputTransition != null):
 		var coreModule = stateHandle.ConfigData().GetModuleSlot(Castagne.MODULE_SLOTS_BASE.CORE)
@@ -252,9 +253,6 @@ func ReactionPhaseStartEntity(stateHandle):
 			coreModule.Flag([inputTransition["TargetFlag"]], stateHandle)
 		if(inputTransition.has("TargetFlagNext")):
 			coreModule.FlagNext([inputTransition["TargetFlagNext"]], stateHandle)
-	stateHandle.EntitySet("_SelectedInputTransition",null)
-	stateHandle.EntitySet("_FrozenInputTransitionList", stateHandle.EntityGet("_InputTransitionList"))
-	stateHandle.EntitySet("_SelectedFrozenInputTransition", null)
 
 func FindCorrectInputTransition(stateHandle):
 	var inputTransitionList = stateHandle.EntityGet("_InputTransitionList")
@@ -496,106 +494,73 @@ func AddInputTransitionFlag(stateHandle, inputNotation, targetState = null, targ
 		itd["TargetFlag"] = targetFlag
 	if(targetFlagNext != null):
 		itd["TargetFlagNext"] = targetFlagNext
-
+	
 	Castagne.FuseDataOverwrite(itd, data)
-
+	
 	stateHandle.EntityAdd("_InputTransitionList", [itd])
 
-#motion input stuff:
+#creates log of inputs ordered from newest to oldest
 func LogDirectionalInputs(stateHandle):
 	var inputs = stateHandle.EntityGet("_Inputs")
 	var buffer = stateHandle.ConfigData().Get("DirectionalInputBuffer")
 	var direction = 5
 	var inputLog = stateHandle.EntityGet("_DirectionalInputLog")
-
-	var minChargeTime = stateHandle.ConfigData().Get("MinChargeTime")
-	var chargeTime = stateHandle.EntityGet("_ChargeTime")
-	var chargeLog = stateHandle.EntityGet("_ChargeInputLog")
-	var currentCharge = []
-
+	
 	if inputLog.empty():
 		inputLog.resize(buffer)
 		inputLog.fill(5)
-	if chargeLog.empty():
-		chargeLog.resize(buffer)
-		chargeLog.fill([])
-
+	
 	if(inputs["Up"]):
-		chargeTime["Up"] += 1
 		direction += 3
-	else:
-		chargeTime["Up"] = 0
-
+	
 	if(inputs["Down"]):
-		chargeTime["Down"] += 1
 		direction -= 3
-	else:
-		chargeTime["Down"] = 0
+	
 	if(inputs["Forward"]):
-		chargeTime["Forward"] += 1
 		direction += 1
-	else:
-		chargeTime["Forward"] = 0
-
+	
 	if(inputs["Back"]):
-		chargeTime["Back"] += 1
 		direction -= 1
-	else:
-		chargeTime["Back"] = 0
-
+	
 	direction = str(direction)
-
-	if chargeTime["Down"] >= minChargeTime:
-		if chargeTime["Back"] >= minChargeTime:
-			currentCharge += ["1"]
-		currentCharge += ["2"]
-		if chargeTime["Forward"] >= minChargeTime:
-			currentCharge += ["3"]
-
-	if chargeTime["Back"] >= minChargeTime:
-		currentCharge += ["4"]
-
-	if chargeTime["Forward"] >= minChargeTime:
-		currentCharge += ["6"]
-
-	if chargeTime["Up"] >= minChargeTime:
-		if chargeTime["Back"] >= minChargeTime:
-			currentCharge += ["7"]
-		currentCharge += ["8"]
-		if chargeTime["Forward"] >= minChargeTime:
-			currentCharge += ["9"]
-
+	
 	inputLog.push_front(direction)
 	inputLog.resize(buffer)
 	stateHandle.EntitySet("_DirectionalInputLog", inputLog)
 
-	chargeLog.push_front(currentCharge)
-	chargeLog.resize(buffer)
-	stateHandle.EntitySet("_ChargeInputLog", chargeLog)
-
-	stateHandle.EntitySet("_ChargeTime", chargeTime)
-
+#checks the input log to see if a motion was done
 func MotionInputCheck(stateHandle, motion):
 	var inputLog = stateHandle.EntityGet("_DirectionalInputLog")
-	var chargeLog = stateHandle.EntityGet("_ChargeInputLog")
 	var minChargeTime = stateHandle.ConfigData().Get("MinChargeTime")
+	var strictDiag = stateHandle.ConfigData().Get("StrictDiagonalCharge")
 	
 	var inputFrames = [0]
-
+	
 	var directions = []
-
+	
+	#convert the notation from str to array and reverse the order so the latest inputs are checked first
 	for i in len(motion):
 		if motion[i] == "]":
 			pass
+		elif i > 0 && motion[i-1] == "[" && !strictDiag:
+			if motion[i] == "2":
+				directions.push_front("123")
+			elif motion[i] == "4":
+				directions.push_front("147")
+			elif motion[i] == "6":
+				directions.push_front("369")
+			elif motion[i] == "8":
+				directions.push_front("789")
+			else:
+				directions.push_front(motion[i])
 		else:
 			directions.push_front(motion[i])
-
 		if i > 0 && motion[i] == motion[i-1]:
 			directions.insert(1,"5")
-
+	
 	var intervals = []
 	intervals.resize(len(directions)-1)
-
+	
 	if len(directions) <= 3:
 		intervals.fill(stateHandle.ConfigData().Get("ShortMotionInterval"))
 	else:
@@ -603,30 +568,49 @@ func MotionInputCheck(stateHandle, motion):
 	intervals.append(stateHandle.ConfigData().Get("ButtonInterval"))
 
 	for i in range(0, len(directions)):
+		#need "[" to mark charges but it doesn't need to be parsed - this should really only be a factor if the motion has a charge partway through it
 		if directions[i] == "[":
-			inputFrames.append(inputLog.find_last(directions[i-1]))
+			inputFrames.append(inputLog[i-1])
 		else:
 			var frame = -1
+			#if the input is a charge, check if there is a sequence of consective inputs longer than the charge time
 			if i < len(directions)-1 && directions[i+1] == "[":
-				for j in range(inputFrames[i],inputFrames[i]+intervals[i]):
-					if !chargeLog[j].find(directions[i]) == -1:
-						frame = j
+				var count = 0
+				var maxCharge = 0
+				var firstFrame = 0
+				for j in range(inputFrames[i],inputFrames[i]+intervals[i]+minChargeTime):
+					if inputLog[j] in directions[i]:
+						count += 1
+						if count > maxCharge:
+							maxCharge = count
+							firstFrame = j
+					else:
+						count = 0
+				if maxCharge >= minChargeTime:
+					inputFrames.append(firstFrame)
+				else:
+					return
+			#otherwise, just check if the input is present in the log between the previous input and the buffer interval
 			else:
 				frame = inputLog.find(directions[i],inputFrames[i])
-			inputFrames.append(frame)
-			if !frame in range(inputFrames[i],inputFrames[i]+intervals[i]):
-				return
+				if frame in range(inputFrames[i],inputFrames[i]+intervals[i]):
+					inputFrames.append(frame)
+				else:
+					return
 	return motion
 
+#parses possible motions and aliases from the input transition list 
 func GetMotionsFromInputList(stateHandle, itl):
 	var validChars = ["0","1","2","3","4","5","6","7","8","9","[","]"]
 	var motionList = []
 	for i in range(0, len(itl)):
 		var motion = ""
 		var input = itl[i]["InputNotation"]
+		#for each input, pulls only the valid characters
 		for c in range(0, len(input)):
 			if validChars.has(input[c]):
 				motion += input[c]
+		#if the input has 2 or more valid characters, it is counted as a motion
 		if len(motion) > 1 and !motionList.has(motion):
 			motionList += [motion]
 			var aliases = GetMotionAliases(stateHandle, motion)
@@ -635,6 +619,7 @@ func GetMotionsFromInputList(stateHandle, itl):
 					motionList += [aliases[a]]
 	return motionList
 
+#pulls the aliases of a motion input from the config
 func GetMotionAliases(stateHandle, motion):
 	var motionAliases = stateHandle.ConfigData().Get("MotionAliases")
 	for dict in motionAliases:
@@ -642,6 +627,7 @@ func GetMotionAliases(stateHandle, motion):
 			return Castagne.SplitStringToArray(dict["Aliases"])
 	return []
 
+#checks the list of possible motions to determine which ones, if any, were performed
 func GetMotionInputs(stateHandle, validMotions):
 	var motions = []
 	
@@ -653,6 +639,7 @@ func GetMotionInputs(stateHandle, validMotions):
 				motions += [mainMotion]
 	return motions
 
+#finds the main motion given an alias
 func GetMainMotion(stateHandle, alias):
 	var motionAliases = stateHandle.ConfigData().Get("MotionAliases")
 	for dict in motionAliases:


### PR DESCRIPTION
Attack states that use numpad notation motion inputs will now automatically be parsed, so there is no need to manually add the motion to the config. 
A menu for adding motion input aliases has been added to the advanced config. Aliases are alternate motions that will trigger the main motion's state when performed. A new option for strict diagonal charges has also been added to make holding a diagonal not also charge the two cardinal directions.
A bug where you could cancel out of hitstun by pressing an input during hitstop (due to the cancels from the previous state being used) has been fixed. You are still able to queue inputs during hitstop, but they are now properly checked to make sure they can be transitioned to from the current entity state.
The way charge inputs were tracked and detected has been changed, which should make future support for per-move properties easier to implement. 
This pull request is contributed under the MIT license.