### PR TITLE
Update CMAudio_MusicPlayer.gd

### DIFF
--- a/modules/general/CMAudio_MusicPlayer.gd
+++ b/modules/general/CMAudio_MusicPlayer.gd
@@ -10,7 +10,7 @@ var loopStart = 0
 func InitFromData(musicData):
 	var fp = musicData["Filepath"]
 	var f = File.new()
-	if(!f.file_exists(fp)):
+	if(!f.file_exists(fp+".import")):
 		Castagne.Error("CMAudio_MusicPlayer: Couldn't find file "+str(fp))
 		return
 	var audioStream = load(fp)


### PR DESCRIPTION
When searching if the audio file exists it will now look for the filename with the ".import" extension added on. Without this the music player will not play audio files when a project is exported.