### PR TITLE
Post Game Jam Patch

### DIFF
--- a/helpers/menus/helpers/css/CMenu-CSS-Player.gd
+++ b/helpers/menus/helpers/css/CMenu-CSS-Player.gd
@@ -129,6 +129,9 @@ func _process(delta):
 				UpdateDisplay()
 			if(i["Right"]):
 				selectedPalette += 1
+				var paletteNumber = selectedCharacter["TransformedData"]["Graphics"]["Palettes"].size()
+				if(selectedPalette > paletteNumber):
+					selectedPalette = paletteNumber
 				UpdateDisplay()
 			
 	elif(menuState == MENUSTATE.CHARACTER):

--- a/helpers/menus/helpers/options/CME-RebindAction.gd
+++ b/helpers/menus/helpers/options/CME-RebindAction.gd
@@ -51,6 +51,18 @@ func _input(event):
 		Castagne.PlayerConfig_Set("bindings-"+optionData["GodotAction"], event.get_scancode())
 		Castagne.PlayerConfig_Save()
 		EndRebind()
+	if event is InputEventJoypadButton and event.is_pressed():
+		InputMap.action_erase_events(optionData["GodotAction"])
+		InputMap.action_add_event(optionData["GodotAction"], event)
+		Castagne.PlayerConfig_Set("bindings-"+optionData["GodotAction"], event.get_button_index())
+		Castagne.PlayerConfig_Save()
+		EndRebind()
+	if event is InputEventJoypadMotion and event.is_pressed():
+		InputMap.action_erase_events(optionData["GodotAction"])
+		InputMap.action_add_event(optionData["GodotAction"], event)
+		Castagne.PlayerConfig_Set("bindings-"+optionData["GodotAction"], event.get_axis())
+		Castagne.PlayerConfig_Save()
+		EndRebind()
 
 func EndRebind():
 	RefreshBind()

--- a/helpers/menus/menus/CMenu-Options.gd
+++ b/helpers/menus/menus/CMenu-Options.gd
@@ -46,10 +46,8 @@ func SetupMouseRebindSelect():
 	var sceneRoot = VBoxContainer.new()
 	var label = Label.new()
 	label.set_text("Rebind Controls of Device:")
-	label.set_align(Label.ALIGN_CENTER)
 	sceneRoot.add_child(label)
 	var root = HFlowContainer.new()
-	root.set_alignment(FlowContainer.ALIGN_CENTER)
 	sceneRoot.add_child(root)
 	
 	for dID in range(deviceList.size()):


### PR DESCRIPTION
Removed code that caused default options scene to crash, extended rebind action to work for controllers, and made palette selection only select actually used palette numbers instead of infinitely counting up. I release this under the MIT license.